### PR TITLE
[ci] Fix on-pull-request GHActions workflow

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,28 +1,42 @@
-name: on-pull-request
-run-name: CI for PR-${{ github.event.number }} (@${{ github.actor }})
+run-name: "PR-${{ github.event.number }}: ${{ github.event.pull_request.title }} (@${{ github.actor }})"
 
 on:
-  pull_request:
-    branches: [$default-branch]
-  push:
-    branches: [$default-branch]
+  - pull_request
 
 env:
-  CARGO_TERM_COLOR: always
+  CARGO_TERM_COLOR: "always"
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  cargo-build-test-clippy:
+    runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v4
-      - name: Build
-        run: cargo build --verbose
-      - name: Test
-        run: cargo test --verbose
+      - uses: "actions/checkout@v4"
 
-  clippy:
-    runs-on: ubuntu-latest
+      - name: "`cargo build`"
+        run: "${GITHUB_WORKSPACE}/scripts/ci/on-pull-request.cargo-build.sh"
+
+      - name: "`cargo test`"
+        run: "${GITHUB_WORKSPACE}/scripts/ci/on-pull-request.cargo-test.sh"
+
+      - name: "`cargo clippy`"
+        run: "${GITHUB_WORKSPACE}/scripts/ci/on-pull-request.cargo-clippy.sh"
+
+  report-test-coverage:
+    needs: "cargo-build-test-clippy"
+    runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v4
-      - name: Clippy
-        run: cargo clippy
+      - name: "Install cargo-llvm-cov"
+        uses: "taiki-e/install-action@cargo-llvm-cov"
+
+      - uses: "actions/checkout@v4"
+
+      - name: "Generate test coverage report"
+        run: "${GITHUB_WORKSPACE}/scripts/ci/on-pull-request.gen-test-coverage-report.sh"
+
+      - name: "Upload test coverage report artifact"
+        uses: "actions/upload-artifact@v4"
+        with:
+          if-no-files-found: "error"
+          name: "Test Coverage Report"
+          path: "target/llvm-cov"
+          retention-days: 14

--- a/scripts/ci/on-pull-request.cargo-build.sh
+++ b/scripts/ci/on-pull-request.cargo-build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd "${GITHUB_WORKSPACE}"
+cargo build --verbose

--- a/scripts/ci/on-pull-request.cargo-clippy.sh
+++ b/scripts/ci/on-pull-request.cargo-clippy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cd "${GITHUB_WORKSPACE}"
+# TODO: Make clippy warnings fail this CI job...
+#       (For now we have some "unused code" warnings that should eventually go
+#       away with more tests)
+#cargo clippy -- -Dwarnings
+cargo clippy

--- a/scripts/ci/on-pull-request.cargo-test.sh
+++ b/scripts/ci/on-pull-request.cargo-test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd "${GITHUB_WORKSPACE}"
+cargo test --verbose

--- a/scripts/ci/on-pull-request.gen-test-coverage-report.sh
+++ b/scripts/ci/on-pull-request.gen-test-coverage-report.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd "${GITHUB_WORKSPACE}"
+cargo llvm-cov --all-features --workspace --html

--- a/scripts/generate-test-coverage-report.sh
+++ b/scripts/generate-test-coverage-report.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+CARGO_LLVM_COV_INSTALLED="$(cargo --list|grep llvm-cov)"
+if [ -z "${CARGO_LLVM_COV_INSTALLED}" ]; then
+  >&2 echo "It looks like cargo-llvm-cov is not installed!"
+  >&2 echo "Please install it before running this script:"
+  >&2 echo
+  >&2 echo "    https://github.com/taiki-e/cargo-llvm-cov"
+  >&2 echo
+  exit 1
+fi
+
+echo "Generating coverage report..."
+cargo llvm-cov --all-features --workspace --html
+
+# If this is an interactive shell AND macos, prompt to open the report in a
+# browser
+if [ -t 0 ] && [[ "$OSTYPE" == "darwin"* ]]; then
+  echo
+  read -r -p "Open the report in a browser? [y/N] " response
+  case "$response" in
+    [yY])
+      CARGO_PKG_ROOT_DIR="$(dirname $(cargo locate-project --message-format plain))"
+      open "${CARGO_PKG_ROOT_DIR}"/target/llvm-cov/html/index.html
+      ;;
+
+    *)
+      echo "Not opening report."
+      ;;
+  esac
+fi


### PR DESCRIPTION
The `on-pull-request` GitHub actions workflow wasn't triggering properly. This fixes it to trigger properly and also generates test-coverage reports as artifacts in a separate job.